### PR TITLE
Fix errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ## Installation
 
 ```
-yarn add --dev @eth-dx/sdk-cli @eth-dx/sdk-client
+yarn add --dev @eth-dx/sdk-cli @eth-dx/sdk-client typescript ethers
 ```
 
 ## Getting started
@@ -53,7 +53,7 @@ import { ethers } from 'ethers'
 
 async function main() {
   const mainnetProvider = ethers.getDefaultProvider('mainnet')
-  const defaultSigner = ethers.Wallet.createRandom(mainnetProvider)
+  const defaultSigner = ethers.Wallet.createRandom().connect(mainnetProvider)
 
   const sdk = await getMainnetSdk(defaultSigner) // default signer will be wired with all contract instances
 


### PR DESCRIPTION
I followed the tutorial in the readme, and got these errors:

* `yarn eth-sdk` failed because `typescript` wasn't installed.
* The snippet that explains how to use it failed because `ethers` was missing.
* The snippet also failed because the wallet had no provider.

This PR fixes all of them.